### PR TITLE
Wrap images in imageTag after upload. Fixed #9

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -4,3 +4,4 @@ Dmitry Mukhin <dm@uploadcare.com>
 Jason Pirkey <jason@pirkplace.com>
 Tim Kleier <tim.kleier@elic.org>
 Timon van Spronsen <timonvanspronsen@outlook.com>
+Andy Abgottspon <andy.abgottspon@hazu.io>

--- a/uploadcare.js
+++ b/uploadcare.js
@@ -16,6 +16,11 @@
                     $opts.version = '2.10.0';
                 }
 
+                // Use imageTag from redactor config
+                if (this.opts.imageTag) {
+                    $opts.imageTag = this.opts.imageTag;
+                }
+
                 if (typeof uploadcare === 'undefined') {
                     var widget_url = 'https://ucarecdn.com/widget/' + $opts.version + '/uploadcare/uploadcare.min.js';
                     $.getScript(widget_url);
@@ -52,7 +57,9 @@
                                 imageUrl += '-/preview/';
                             }
                             if (this.isImage) {
-                                $this.insert.html('<img src="' + imageUrl + '" alt="' + this.name + '" />', false);
+                                var openTag = $opts.imageTag ? '<' + $opts.imageTag + '>' : '';
+                                var closeTag = $opts.imageTag ? '</' + $opts.imageTag + '>' : '';
+                                $this.insert.html(openTag + '<img src="' + imageUrl + '" alt="' + this.name + '" />' + closeTag, false);
                             } else {
                                 $this.insert.html('<a href="' + this.cdnUrl + '">' + this.name + '</a>', false);
                             }


### PR DESCRIPTION
This wraps the generated image tag in the imageTag as defined by the parent redactor.

See: https://imperavi.com/redactor/docs/settings/images/#setting-imageTag

It fixes a problem I was seeing when editing caption.

